### PR TITLE
Enable image replacements when no image was found

### DIFF
--- a/inc/class-resize-image.php
+++ b/inc/class-resize-image.php
@@ -39,7 +39,17 @@ if ( ! class_exists( 'OIR_Resize_Image' ) ) :
       $meta = wp_get_attachment_metadata( $id );
       $wanted_width = $wanted_height = 0;
 
-      if ( empty( $meta['file'] ) ) return false;
+      if ( empty( $meta['file'] ) ) {
+		
+        // Check if we can replace with a placeholder image
+        if ( defined('OIR_PLACEHOLDER_IMAGE_ID') ) {
+          $meta = wp_get_attachment_metadata( OIR_PLACEHOLDER_IMAGE_ID );
+          if ( empty( $meta['file'] ) ) return false;
+          $id = OIR_PLACEHOLDER_IMAGE_ID;
+        } else {
+          return false;	
+        }
+      }
 
       // get $size dimensions
       global $_wp_additional_image_sizes;
@@ -69,7 +79,10 @@ if ( ! class_exists( 'OIR_Resize_Image' ) ) :
 
       }
 
-      if ( $intermediate = image_get_intermediate_size( $id, $size ) ) {
+      $intermediate = image_get_intermediate_size( $id, $size );
+	    
+      // check if the image size was changed and needs to regenerate
+	    if ( $intermediate && ( $intermediate['width'] == $wanted_width && $intermediate['height'] ==  $wanted_height ) ) {
 
         $img_url = wp_get_attachment_url( $id );
         $img_url_basename = wp_basename( $img_url );


### PR DESCRIPTION
I'm sending you an idea to create empty images to replace posts with no thumbnails in a website that requires one. In this small feature, when you set `OIR_PLACEHOLDER_IMAGE_ID` with an attachment ID, this image will be used when there is no image to show when you call a function like `wp_get_attachment_image()`, the image will be replaced with another one. Enabling this you always show some image on the site and this can be useful to remember the Editor that he missed something when publishing. 

If you got the idea and accept the feature, to make this even more easy to use, you could create a form to upload the placeholder image. Maybe this form could be placed on **Settings > Media** page and your current tool to remove images could join this place too as those features represents a Media setting.

I would like to read your opinion about this, I have my own thumbnail plugin that includes this placeholder feature, but your idea is more WP friendly and maybe I'll rebuild my plugin or use yours.

I put another small feature in the code to check if the image size changed so the script can replace it with the new size instead of you go to the tool to remove all created images, this is very common situation in development when you are testing the best image size for the layout.